### PR TITLE
Treat default mode as production

### DIFF
--- a/Model/IgnitionFactory.php
+++ b/Model/IgnitionFactory.php
@@ -24,6 +24,6 @@ class IgnitionFactory
             ->applicationPath(BP)
             ->sendToFlare($flareApiKey)
             ->addSolutionProviders($this->solutionProviders)
-            ->runningInProductionEnvironment($this->state->getMode() === State::MODE_PRODUCTION);
+            ->runningInProductionEnvironment($this->state->getMode() !== State::MODE_DEVELOPER);
     }
 }


### PR DESCRIPTION
Thanks for the module! Much nicer error pages.

I think a change would be appropriate, though:  Right now production mode blocks the error pages, but default mode does not. I think Ignition error pages should display only in developer mode. People _shouldn't_ run Magento in default mode, but many probably do. We don't want to disclose error details for anyone that does have this installed on a live site in default mode.